### PR TITLE
Improve index html deployment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ listen_ssl: "443 ssl default_server"
 novnc_upstreams: []
 
 fabric_wwwroot: "/var/www/fabric"
-
+fabric_index_template: "index.html.j2"
 fabric_version: "latest"
 fabric_release_url: "https://github.com/ait-cs-IaaS/fabric/releases/download"
 

--- a/tasks/fabric.yml
+++ b/tasks/fabric.yml
@@ -1,17 +1,17 @@
 ---
 - name: Create fabric directory
   file:
-    path: "/var/www/fabric"
+    path: "{{ fabric_wwwroot }}"
     state: directory
     mode: 0755
 
 - name: Create novnc HTML
   template:
-    dest: "/var/www/fabric/index.html"
+    dest: "{{ fabric_wwwroot }}/index.html"
     src: "{{ fabric_index_template }}"
     mode: 0644
 
 - name: Download fabric
   get_url:
     url: "{{ fabric_release_url }}/{{ fabric_version }}/main.js"
-    dest: "/var/www/fabric/main.js"
+    dest: "{{ fabric_wwwroot }}/main.js"

--- a/tasks/fabric.yml
+++ b/tasks/fabric.yml
@@ -8,7 +8,7 @@
 - name: Create novnc HTML
   template:
     dest: "/var/www/fabric/index.html"
-    src: index.html.j2
+    src: "{{ fabric_index_template }}"
     mode: 0644
 
 - name: Download fabric

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <script src="main.js" defer></script>
 </head>
-<body>
+<body style="margin: 0; padding: 0;">
     <div id="fabric"></div>
 </body>
 </html>


### PR DESCRIPTION
## Fixes 

- `fabric_wwwroot` not being used in some tasks

## Changes
- Disable margin and padding for the default index file
- Make index template file configurable to allow for using custom templates

## Make sure to check points below to increase ikelihood of your pull request being accepted:

- [ ] I have updated the documentation
- [ ] I have added tests to cover my changes
- [x] I checked if all new and existing tests passed
- [x] I checked if I followed standards for style and code quality
- [ ] I created an Issue describeing why this change is necessary
